### PR TITLE
Add hash for tmp dir location.

### DIFF
--- a/System/Posix/ARX/CLI/Options.hs
+++ b/System/Posix/ARX/CLI/Options.hs
@@ -39,7 +39,7 @@ shdat                        =  do
     f _ stuff                =  stuff
 
 tmpx :: ArgsParser ( [Word], [IOStream], [IOStream], [(Sh.Var, Sh.Val)],
-                     [(Bool, Bool)], [ByteSource]                        )
+                     [(Bool, Bool, Bool)], [ByteSource]                        )
 tmpx                         =  do
   arg "tmpx"
   bars                      <-  (try . lookAhead) slashes
@@ -91,9 +91,10 @@ ioStream                     =  STDIO <$  tokCL Dash
 qPath                       ::  ArgsParser ByteString
 qPath                        =  tokCL QualifiedPath
 
-rm                          ::  ArgsParser (Bool, Bool)
-rm  =   (True,  False) <$ arg "-rm0"  <|>  (False, True) <$ arg "-rm1"
-   <|>  (False, False) <$ arg "-rm!"  <|>  (True,  True) <$ arg "-rm_"
+rm                          ::  ArgsParser (Bool, Bool, Bool)
+rm  =   (True,  False, False) <$ arg "-rm0"  <|>  (False, True, False) <$ arg "-rm1"
+   <|>  (False, False, False) <$ arg "-rm!"  <|>  (True,  True, False) <$ arg "-rm_"
+   <|>  (False, False, True)  <$ arg "-rm."
 
 env                         ::  ArgsParser (Sh.Var, Sh.Val)
 env                          =  do

--- a/System/Posix/ARX/Programs.hs
+++ b/System/Posix/ARX/Programs.hs
@@ -59,9 +59,10 @@ data TMPX = TMPX SHDAT LazyB.ByteString -- Code of task to run.
                        [(Sh.Var, Sh.Val)] -- Environment mapping.
                        Bool -- Destroy tmp if task runs successfully.
                        Bool -- Destroy tmp if task exits with an error code.
+                       Bool -- Reuse tmp dir if available.
 instance ARX TMPX [(Tar, LazyB.ByteString)] where
-  interpret (TMPX encoder run env rm0 rm1) stuff = TMPXTools.render
-    (TMPXTools.Template rm0 rm1 env' run' archives)
+  interpret (TMPX encoder run env rm0 rm1 rm2) stuff = TMPXTools.render
+    (TMPXTools.Template rm0 rm1 rm2 env' run' archives)
    where
     archives                 =  mconcat (uncurry archive <$> stuff)
     archive tar bytes        =  mconcat

--- a/System/Posix/ARX/TMPXTools.hs
+++ b/System/Posix/ARX/TMPXTools.hs
@@ -14,6 +14,9 @@ import Data.Monoid
 import qualified Blaze.ByteString.Builder as Blaze
 import Data.FileEmbed
 
+import Data.Hashable (hash)
+import Numeric (showIntAtBase)
+import Data.Char (intToDigit)
 
 data Template = Template { rm0 :: Bool, {-^ Remove tmp on run success?    -}
                            rm1 :: Bool, {-^ Remove tmp on run error?      -}
@@ -29,7 +32,7 @@ instance Show Template where
 
 render                      ::  Template -> Blaze.Builder
 render Template{..}          =  mconcat [ blaze a,
-                                          flags, 
+                                          flags,
                                           blaze b,
                                           env,
                                           blaze c,
@@ -38,7 +41,10 @@ render Template{..}          =  mconcat [ blaze a,
                                           dat,
                                           blaze e ]
  where
-  flags                      =  mconcat ["rm0=",tf rm0," ; ","rm1=",tf rm1,"\n"]
+  flags                      =  mconcat [ "rm0=", tf rm0, " ; ",
+                                          "rm1=", tf rm1, " ; ",
+                                          "hash=", hash' dat, "\n"]
+  hash'                      =  blaze . Bytes.pack . (\x -> showIntAtBase 16 intToDigit x "") . abs . hash . Blaze.toByteString
   blaze                      =  Blaze.fromByteString
   tf True                    =  "true"
   tf False                   =  "false"

--- a/System/Posix/ARX/TMPXTools.hs
+++ b/System/Posix/ARX/TMPXTools.hs
@@ -43,8 +43,10 @@ render Template{..}          =  mconcat [ blaze a,
  where
   flags                      =  mconcat [ "rm0=", tf rm0, " ; ",
                                           "rm1=", tf rm1, " ; ",
-                                          "hash=", hash' dat, "\n"]
+                                          "rm2=", tf rm2, " ; ",
+                                          "token=", (if rm2 then hash' dat else token'), "\n"]
   hash'                      =  blaze . Bytes.pack . (\x -> showIntAtBase 16 intToDigit x "") . abs . hash . Blaze.toByteString
+  token'                     =  "`date -u +%FT%TZ | tr :- ..`-`hexdump -n4 -e '\"%08x\"' </dev/urandom`"
   blaze                      =  Blaze.fromByteString
   tf True                    =  "true"
   tf False                   =  "false"

--- a/arx.cabal
+++ b/arx.cabal
@@ -77,6 +77,7 @@ library
                               , process >= 1.0
                               , shell-escape >= 0.1.1
                               , template-haskell
+                              , hashable
   exposed-modules             : System.Posix.ARX
                                 System.Posix.ARX.CLI
                                 System.Posix.ARX.CLI.CLTokens
@@ -111,6 +112,7 @@ executable                      arx
                               , process >= 1.0
                               , shell-escape >= 0.1.1
                               , template-haskell
+                              , hashable
   extensions                  : FlexibleInstances
                                 FunctionalDependencies
                                 MultiParamTypeClasses


### PR DESCRIPTION
This sets up the tmp directory to extract the archive. The location
will be /tmp/tmpx-TOKEN where TOKEN is a hash of the dat archive. This
lets us reuse the archive after each run.

Fixes #3.

Depending on support for this, I can make it optional so we can keep the old generated TMPDIR method.