### PR TITLE
Custom tmpdir arg (first try)

### DIFF
--- a/System/Posix/ARX/CLI.hs
+++ b/System/Posix/ARX/CLI.hs
@@ -114,7 +114,8 @@ tmpxCheckStreams tars cmd    =  streamsMessage [tars', cmd']
     | cmd == IOStream STDIO  =  One "as a command input"
     | otherwise              =  Zero
 
-tmpxOpen :: Word -> [(Var, Val)] -> (Bool, Bool, Bool) -> ByteString -> ByteSource -> IO TMPX
+tmpxOpen :: Word -> [(Var, Val)] -> (Bool, Bool, Bool)
+         -> ByteString -> ByteSource -> IO TMPX
 tmpxOpen size env (rm0, rm1, rm2) tmpdir cmd = do
   text                      <-  case cmd of
     ByteString b            ->  return (LazyB.fromChunks [b])

--- a/System/Posix/ARX/CLI.hs
+++ b/System/Posix/ARX/CLI.hs
@@ -88,10 +88,10 @@ shdatCheckStreams ins        =  streamsMessage [ins']
 {-| Apply defaulting and overrides appropriate to 'TMPX' programs.
  -}
 tmpxResolve                 ::  ( [Word], [IOStream], [IOStream],
-                                  [(Var, Val)], [String], [(Bool, Bool)],
+                                  [(Var, Val)], [ByteString], [(Bool, Bool)],
                                   [Bool], [ByteSource]              )
                             ->  ( Word, IOStream, [IOStream],
-                                  [(Var, Val)], String, (Bool, Bool), Bool,
+                                  [(Var, Val)], ByteString, (Bool, Bool), Bool,
                                   ByteSource                        )
 tmpxResolve (sizes, outs, tars, env, dirs, rms, shareds, cmds) =
   (size, out, tars, env, tmpdir, rm, shared, cmd)
@@ -114,13 +114,13 @@ tmpxCheckStreams tars cmd    =  streamsMessage [tars', cmd']
     | cmd == IOStream STDIO  =  One "as a command input"
     | otherwise              =  Zero
 
-tmpxOpen :: Word -> [(Var, Val)] -> (Bool, Bool, Bool) -> ByteSource -> IO TMPX
-tmpxOpen size env (rm0, rm1, rm2) cmd = do
+tmpxOpen :: Word -> [(Var, Val)] -> (Bool, Bool, Bool) -> ByteString -> ByteSource -> IO TMPX
+tmpxOpen size env (rm0, rm1, rm2) tmpdir cmd = do
   text                      <-  case cmd of
     ByteString b            ->  return (LazyB.fromChunks [b])
     IOStream STDIO          ->  LazyB.getContents
     IOStream (Path b)       ->  LazyB.readFile (Char8.unpack b)
-  return (TMPX (SHDAT size) text env rm0 rm1 rm2)
+  return (TMPX (SHDAT size) text env tmpdir rm0 rm1 rm2)
 
 
 openByteSource              ::  ByteSource -> IO LazyB.ByteString

--- a/System/Posix/ARX/CLI/Options.hs
+++ b/System/Posix/ARX/CLI/Options.hs
@@ -54,31 +54,34 @@ tmpx                         =  do
   flags                      =  manyTill flag
   gather = (ByteString . Char8.unwords <$>) . manyTill anyArg
   flag                       =  _1 blockSize <|> _2 outputFile <|> _3 ioStream
-                            <|> _4 env       <|> _5 rm         <|> _6 shared
-                            <|> _7 scriptToRun
-  _1 = ((,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing) . Just <$>)
-  _2 = ((Nothing,,Nothing,Nothing,Nothing,Nothing,Nothing) . Just <$>)
-  _3 = ((Nothing,Nothing,,Nothing,Nothing,Nothing,Nothing) . Just <$>)
-  _4 = ((Nothing,Nothing,Nothing,,Nothing,Nothing,Nothing) . Just <$>)
-  _5 = ((Nothing,Nothing,Nothing,Nothing,,Nothing,Nothing) . Just <$>)
-  _6 = ((Nothing,Nothing,Nothing,Nothing,Nothing,,Nothing) . Just <$>)
-  _7 = ((Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,) . Just <$>)
+                            <|> _4 env       <|> _5 tmpdir     <|> _6 rm
+                            <|> _7 shared    <|> _8 scriptToRun
+  _1 = ((,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing) . Just <$>)
+  _2 = ((Nothing,,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing) . Just <$>)
+  _3 = ((Nothing,Nothing,,Nothing,Nothing,Nothing,Nothing,Nothing) . Just <$>)
+  _4 = ((Nothing,Nothing,Nothing,,Nothing,Nothing,Nothing,Nothing) . Just <$>)
+  _5 = ((Nothing,Nothing,Nothing,Nothing,,Nothing,Nothing,Nothing) . Just <$>)
+  _6 = ((Nothing,Nothing,Nothing,Nothing,Nothing,,Nothing,Nothing) . Just <$>)
+  _7 = ((Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,,Nothing) . Just <$>)
+  _8 = ((Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,) . Just <$>)
   coalesce                   =  foldr f ([], [], [], [], [], [], [])
    where
-    f (Just a, _, _, _, _, _, _)   (as, bs, cs, ds, es, fs, gs)
-                                =  (a:as, bs, cs, ds, es, fs, gs)
-    f (_, Just b, _, _, _, _, _)   (as, bs, cs, ds, es, fs, gs)
-                                =  (as, b:bs, cs, ds, es, fs, gs)
-    f (_, _, Just c, _, _, _, _)   (as, bs, cs, ds, es, fs, gs)
-                                =  (as, bs, c:cs, ds, es, fs, gs)
-    f (_, _, _, Just d, _, _, _)   (as, bs, cs, ds, es, fs, gs)
-                                =  (as, bs, cs, d:ds, es, fs, gs)
-    f (_, _, _, _, Just e, _, _)   (as, bs, cs, ds, es, fs, gs)
-                                =  (as, bs, cs, ds, e:es, fs, gs)
-    f (_, _, _, _, _, Just f, _)   (as, bs, cs, ds, es, fs, gs)
-                                =  (as, bs, cs, ds, es, f:fs, gs)
-    f (_, _, _, _, _, _, Just g)   (as, bs, cs, ds, es, fs, gs)
-                                =  (as, bs, cs, ds, es, fs, g:gs)
+    f (Just a, _, _, _, _, _, _, _)   (as, bs, cs, ds, es, fs, gs, hs)
+                                =  (a:as, bs, cs, ds, es, fs, gs, hs)
+    f (_, Just b, _, _, _, _, _, _)   (as, bs, cs, ds, es, fs, gs, hs)
+                                =  (as, b:bs, cs, ds, es, fs, gs, hs)
+    f (_, _, Just c, _, _, _, _, _)   (as, bs, cs, ds, es, fs, gs, hs)
+                                =  (as, bs, c:cs, ds, es, fs, gs, hs)
+    f (_, _, _, Just d, _, _, _, _)   (as, bs, cs, ds, es, fs, gs, hs)
+                                =  (as, bs, cs, d:ds, es, fs, gs, hs)
+    f (_, _, _, _, Just e, _, _, _)   (as, bs, cs, ds, es, fs, gs, hs)
+                                =  (as, bs, cs, ds, e:es, fs, gs, hs)
+    f (_, _, _, _, _, Just f, _, _)   (as, bs, cs, ds, es, fs, gs, hs)
+                                =  (as, bs, cs, ds, es, f:fs, gs, hs)
+    f (_, _, _, _, _, _, Just g, _)   (as, bs, cs, ds, es, fs, gs, hs)
+                                =  (as, bs, cs, ds, es, fs, g:gs, hs)
+    f (_, _, _, _, _, _, _, Just h)   (as, bs, cs, ds, es, fs, gs, hs)
+                                =  (as, bs, cs, ds, es, fs, gs, h:hs)
     f _ stuff                   =  stuff
 
 blockSize                   ::  ArgsParser Word
@@ -98,6 +101,8 @@ qPath                        =  tokCL QualifiedPath
 shared                      ::  ArgsParser Bool
 shared                       =  True <$ arg "--shared"
 
+tmpdir                       :: ArgsParser Path
+                             = arg "--tmpdir" >> QualifiedPath
 
 rm                          ::  ArgsParser (Bool, Bool)
 rm  =   (True,  False) <$ arg "-rm0"  <|>  (False, True) <$ arg "-rm1"

--- a/System/Posix/ARX/CLI/Options.hs
+++ b/System/Posix/ARX/CLI/Options.hs
@@ -39,7 +39,7 @@ shdat                        =  do
     f _ stuff                =  stuff
 
 tmpx :: ArgsParser ( [Word], [IOStream], [IOStream], [(Sh.Var, Sh.Val)],
-                     [(Bool, Bool)], [Bool], [ByteSource]                )
+                     [ByteString], [(Bool, Bool)], [Bool], [ByteSource] )
 tmpx                         =  do
   arg "tmpx"
   bars                      <-  (try . lookAhead) slashes
@@ -47,7 +47,7 @@ tmpx                         =  do
                  Nothing    ->  flags eof
                  Just bars  ->  do let eof_bars = () <$ arg bars <|> eof
                                    before <- flags eof_bars
-                                   cmd <- _7 (gather eof_bars)
+                                   cmd <- _8 (gather eof_bars)
                                    after <- flags eof
                                    return (before ++ (cmd:after))
  where
@@ -64,7 +64,7 @@ tmpx                         =  do
   _6 = ((Nothing,Nothing,Nothing,Nothing,Nothing,,Nothing,Nothing) . Just <$>)
   _7 = ((Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,,Nothing) . Just <$>)
   _8 = ((Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,) . Just <$>)
-  coalesce                   =  foldr f ([], [], [], [], [], [], [])
+  coalesce                   =  foldr f ([], [], [], [], [], [], [], [])
    where
     f (Just a, _, _, _, _, _, _, _)   (as, bs, cs, ds, es, fs, gs, hs)
                                 =  (a:as, bs, cs, ds, es, fs, gs, hs)
@@ -101,8 +101,8 @@ qPath                        =  tokCL QualifiedPath
 shared                      ::  ArgsParser Bool
 shared                       =  True <$ arg "--shared"
 
-tmpdir                       :: ArgsParser Path
-                             = arg "--tmpdir" >> QualifiedPath
+tmpdir                      ::  ArgsParser ByteString
+tmpdir                       =  arg "--tmpdir" >> tokCL QualifiedPath
 
 rm                          ::  ArgsParser (Bool, Bool)
 rm  =   (True,  False) <$ arg "-rm0"  <|>  (False, True) <$ arg "-rm1"

--- a/System/Posix/ARX/Programs.hs
+++ b/System/Posix/ARX/Programs.hs
@@ -57,12 +57,13 @@ instance ARX SHDAT LazyB.ByteString where
  -}
 data TMPX = TMPX SHDAT LazyB.ByteString -- Code of task to run.
                        [(Sh.Var, Sh.Val)] -- Environment mapping.
+                       String -- Place to put tmp dir.
                        Bool -- Destroy tmp if task runs successfully.
                        Bool -- Destroy tmp if task exits with an error code.
                        Bool -- Reuse tmp dir if available.
 instance ARX TMPX [(Tar, LazyB.ByteString)] where
-  interpret (TMPX encoder run env rm0 rm1 rm2) stuff = TMPXTools.render
-    (TMPXTools.Template rm0 rm1 rm2 env' run' archives)
+  interpret (TMPX encoder run env tmpdir rm0 rm1 rm2) stuff = TMPXTools.render
+    (TMPXTools.Template tmpdir rm0 rm1 rm2 env' run' archives)
    where
     archives                 =  mconcat (uncurry archive <$> stuff)
     archive tar bytes        =  mconcat

--- a/System/Posix/ARX/Programs.hs
+++ b/System/Posix/ARX/Programs.hs
@@ -57,13 +57,13 @@ instance ARX SHDAT LazyB.ByteString where
  -}
 data TMPX = TMPX SHDAT LazyB.ByteString -- Code of task to run.
                        [(Sh.Var, Sh.Val)] -- Environment mapping.
-                       String -- Place to put tmp dir.
+                       ByteString -- Place to put tmp dir.
                        Bool -- Destroy tmp if task runs successfully.
                        Bool -- Destroy tmp if task exits with an error code.
                        Bool -- Reuse tmp dir if available.
 instance ARX TMPX [(Tar, LazyB.ByteString)] where
   interpret (TMPX encoder run env tmpdir rm0 rm1 rm2) stuff = TMPXTools.render
-    (TMPXTools.Template tmpdir rm0 rm1 rm2 env' run' archives)
+    (TMPXTools.Template rm0 rm1 rm2 tmpdir env' run' archives)
    where
     archives                 =  mconcat (uncurry archive <$> stuff)
     archive tar bytes        =  mconcat

--- a/System/Posix/ARX/TMPXTools.hs
+++ b/System/Posix/ARX/TMPXTools.hs
@@ -22,13 +22,14 @@ import Data.Hashable
 data Template = Template { rm0    :: Bool, {-^ Remove tmp on run success?    -}
                            rm1    :: Bool, {-^ Remove tmp on run error?      -}
                            shared :: Bool, {-^ Share directory across runs?  -}
-                           tmpdir :: String, {-^ Location to store tmp files.-}
+                           tmpdir :: ByteString,    {-^ Temp file location.  -}
                            env    :: Blaze.Builder, {-^ Stream for env text. -}
                            run    :: Blaze.Builder, {-^ Stream for run text. -}
                            dat    :: Blaze.Builder  {-^ Data text. -} }
 instance Show Template where
   show Template{..} =
-    "Template { tmpdir=" tmpdir ++ " rm0=" ++ tf rm0 ++ " rm1=" ++ tf rm1 ++
+    "Template { tmpdir=" ++ Bytes.unpack tmpdir
+              ++ " rm0=" ++ tf rm0 ++ " rm1=" ++ tf rm1 ++
               " shared=" ++ tf shared ++  " ... }"
    where
     tf True                  =  "true"
@@ -48,8 +49,8 @@ render Template{..}          =  mconcat [ blaze a,
   flags                      =  mconcat [ "rm0=", tf rm0, " ; ",
                                           "rm1=", tf rm1, " ; ",
                                           "shared=", tf shared, " ; ",
-                                          "hash=", (hexStr . hash) dat,
-                                          "tmpdir=", tmpdir, "\n" ]
+                                          "hash=", (hexStr . hash) dat, " ; ",
+                                          "tmpdir=", blaze tmpdir, "\n" ]
   hash                       =  abs . Data.Hashable.hash . Blaze.toByteString
   hexStr                     =  blaze . Bytes.pack . hex
   hex i = Numeric.showIntAtBase 16 Data.Char.intToDigit i ""

--- a/System/Posix/ARX/TMPXTools.hs
+++ b/System/Posix/ARX/TMPXTools.hs
@@ -22,12 +22,13 @@ import Data.Hashable
 data Template = Template { rm0    :: Bool, {-^ Remove tmp on run success?    -}
                            rm1    :: Bool, {-^ Remove tmp on run error?      -}
                            shared :: Bool, {-^ Share directory across runs?  -}
+                           tmpdir :: String, {-^ Location to store tmp files.-}
                            env    :: Blaze.Builder, {-^ Stream for env text. -}
                            run    :: Blaze.Builder, {-^ Stream for run text. -}
                            dat    :: Blaze.Builder  {-^ Data text. -} }
 instance Show Template where
   show Template{..} =
-    "Template { rm0=" ++ tf rm0 ++ " rm1=" ++ tf rm1 ++
+    "Template { tmpdir=" tmpdir ++ " rm0=" ++ tf rm0 ++ " rm1=" ++ tf rm1 ++
               " shared=" ++ tf shared ++  " ... }"
    where
     tf True                  =  "true"
@@ -47,14 +48,15 @@ render Template{..}          =  mconcat [ blaze a,
   flags                      =  mconcat [ "rm0=", tf rm0, " ; ",
                                           "rm1=", tf rm1, " ; ",
                                           "shared=", tf shared, " ; ",
-                                          "hash=", (hexStr . hash) dat, "\n" ]
+                                          "hash=", (hexStr . hash) dat,
+                                          "tmpdir=", tmpdir, "\n" ]
   hash                       =  abs . Data.Hashable.hash . Blaze.toByteString
   hexStr                     =  blaze . Bytes.pack . hex
   hex i = Numeric.showIntAtBase 16 Data.Char.intToDigit i ""
   blaze                      =  Blaze.fromByteString
   tf True                    =  "true"
   tf False                   =  "false"
-  a : b : c : d : e : [] = findChunks $(embedFile "./model-scripts/tmpx.sh")
+  a : b : c : d : e : f : [] = findChunks $(embedFile "./model-scripts/tmpx.sh")
 
 findChunks                  ::  ByteString -> [ByteString]
 findChunks                   =  coalesce . markHoles

--- a/model-scripts/tmpx.sh
+++ b/model-scripts/tmpx.sh
@@ -39,9 +39,9 @@ opts() {
     if $shared
     then
       rm_=false
-      dir=$tmpdir/tmpx-"$hash"
+      dir="$tmpdir"/tmpx-"$hash"
     else
-      dir=$tmpdir/tmpx-"$token"
+      dir="$tmpdir"/tmpx-"$token"
     fi
     : ${rm_:=true}
     if $rm_

--- a/model-scripts/tmpx.sh
+++ b/model-scripts/tmpx.sh
@@ -2,7 +2,7 @@
 set -e -u
 unset rm_ dir
 tmp=true ; run=true
-rm0=true ; rm1=true ; shared=false ; hash="" # To be set by tool.
+tmpdir= ; rm0=true ; rm1=true ; shared=false ; hash="" # To be set by tool.
 token=`date -u +%FT%TZ | tr -d :-`-`hexdump -n4 -e '"%08x"' </dev/urandom`
 opts() {
   cmd="$1" ; shift
@@ -39,9 +39,9 @@ opts() {
     if $shared
     then
       rm_=false
-      dir=/tmp/tmpx-"$hash"
+      dir=$tmpdir/tmpx-"$hash"
     else
-      dir=/tmp/tmpx-"$token"
+      dir=$tmpdir/tmpx-"$token"
     fi
     : ${rm_:=true}
     if $rm_


### PR DESCRIPTION
Attempt to add a --tmpdir arg.

The --shared option can be very useful but also a little dangerous if
you don’t trust what’s in the /tmp directory. Giving Arx a custom
location for the temp directory should make things a little bit safer.
Most useful in this case,

  $ arx tmpx --shared --tmpdir '$HOME/.cache' my.tar.bz2

This will put things in your HOME directory where you can be fairly
sure no one else has snuck in a temporary directory to fool you into
using something that is malicious.

Using /tmp as a shared directory can be exploited if you know the hash
ahead of time. Just something as simple as this,

  $ tmp=$(mktemp -d tmpx-HASH)
  $ echo "rm -rf /" > $tmp/run

  where HASH is the hash of the dat,

can create a privilege escalation when Arx runs the /run script.

This is already (hackily) done by patching tmpx.sh in nix-bundle, but I would prefer to get it working as an are.

https://github.com/matthewbauer/nix-bundle/blob/master/default.nix#L8-L9