### PR TITLE
Remove two layers of shell

### DIFF
--- a/model-scripts/tmpx.sh
+++ b/model-scripts/tmpx.sh
@@ -72,7 +72,7 @@ go () {
   fi
   if $run
   then
-    ( . ../env && ../run "$@" )
+    { . ../env && exec ../run "$@" }
   fi
 }
 unpack_env () { : # NOOP


### PR DESCRIPTION
Is there a POSIX reason or something else that would prevent reducing the number of sub-shells?