### PR TITLE
Set argv0= to allow multi-executable binaries

### DIFF
--- a/model-scripts/tmpx.sh
+++ b/model-scripts/tmpx.sh
@@ -72,7 +72,7 @@ go () {
   fi
   if $run
   then
-    ( . ../env && exec ../run "$@" )
+    ( . ../env && exec -a "$0" ../run "$@" )
   fi
 }
 unpack_env () { : # NOOP


### PR DESCRIPTION
Some binaries use $0 sniffing to determine what mode to use. So, we
want to propagate the argv0 we are using so we can use these programs.

A good example is “coreutils” which uses this method:

$ tree /nix/store/...-coreutils-8.31
.
├── bin
│   ├── [ -> coreutils
│   ├── b2sum -> coreutils
│   ├── base32 -> coreutils
│   ├── base64 -> coreutils
│   ├── basename -> coreutils
│   ├── basenc -> coreutils
│   ├── cat -> coreutils
│   ├── chcon -> coreutils
│   ├── chgrp -> coreutils
│   ├── chmod -> coreutils
│   ├── chown -> coreutils
│   ├── chroot -> coreutils
│   ├── cksum -> coreutils
│   ├── comm -> coreutils
│   ├── coreutils
│   ├── cp -> coreutils
│   ├── csplit -> coreutils
│   ├── cut -> coreutils
│   ├── date -> coreutils
│   ├── dd -> coreutils
│   ├── df -> coreutils
│   ├── dir -> coreutils
│   ├── dircolors -> coreutils
│   ├── dirname -> coreutils
│   ├── du -> coreutils
│   ├── echo -> coreutils
│   ├── env -> coreutils
│   ├── expand -> coreutils
│   ├── expr -> coreutils
│   ├── factor -> coreutils
│   ├── false -> coreutils
│   ├── fmt -> coreutils
│   ├── fold -> coreutils
│   ├── groups -> coreutils
│   ├── head -> coreutils
│   ├── hostid -> coreutils
│   ├── id -> coreutils
│   ├── install -> coreutils
│   ├── join -> coreutils
│   ├── kill -> coreutils
│   ├── link -> coreutils
│   ├── ln -> coreutils
│   ├── logname -> coreutils
│   ├── ls -> coreutils
│   ├── md5sum -> coreutils
│   ├── mkdir -> coreutils
│   ├── mkfifo -> coreutils
│   ├── mknod -> coreutils
│   ├── mktemp -> coreutils
│   ├── mv -> coreutils
│   ├── nice -> coreutils
│   ├── nl -> coreutils
│   ├── nohup -> coreutils
│   ├── nproc -> coreutils
│   ├── numfmt -> coreutils
│   ├── od -> coreutils
│   ├── paste -> coreutils
│   ├── pathchk -> coreutils
│   ├── pinky -> coreutils
│   ├── pr -> coreutils
│   ├── printenv -> coreutils
│   ├── printf -> coreutils
│   ├── ptx -> coreutils
│   ├── pwd -> coreutils
│   ├── readlink -> coreutils
│   ├── realpath -> coreutils
│   ├── rm -> coreutils
│   ├── rmdir -> coreutils
│   ├── runcon -> coreutils
│   ├── seq -> coreutils
│   ├── sha1sum -> coreutils
│   ├── sha224sum -> coreutils
│   ├── sha256sum -> coreutils
│   ├── sha384sum -> coreutils
│   ├── sha512sum -> coreutils
│   ├── shred -> coreutils
│   ├── shuf -> coreutils
│   ├── sleep -> coreutils
│   ├── sort -> coreutils
│   ├── split -> coreutils
│   ├── stat -> coreutils
│   ├── stdbuf -> coreutils
│   ├── stty -> coreutils
│   ├── sum -> coreutils
│   ├── sync -> coreutils
│   ├── tac -> coreutils
│   ├── tail -> coreutils
│   ├── tee -> coreutils
│   ├── test -> coreutils
│   ├── timeout -> coreutils
│   ├── touch -> coreutils
│   ├── tr -> coreutils
│   ├── true -> coreutils
│   ├── truncate -> coreutils
│   ├── tsort -> coreutils
│   ├── tty -> coreutils
│   ├── uname -> coreutils
│   ├── unexpand -> coreutils
│   ├── uniq -> coreutils
│   ├── unlink -> coreutils
│   ├── uptime -> coreutils
│   ├── users -> coreutils
│   ├── vdir -> coreutils
│   ├── wc -> coreutils
│   ├── who -> coreutils
│   ├── whoami -> coreutils
│   └── yes -> coreutils
└── libexec
    └── coreutils
        └── libstdbuf.so

3 directories, 108 files

It needs argv0 to be set to the real name of the utility. Before it was something like `/tmp/tmpx-20190509T191742Z-4f90c6f0/dat/../run`